### PR TITLE
Fix PHP 7.4 compatibility by modifying union type

### DIFF
--- a/GitHubTheme.php
+++ b/GitHubTheme.php
@@ -69,7 +69,7 @@ class GitHubTheme extends MinimalTheme implements ModuleCustomInterface, ModuleG
      *
      * @return array<Menu>
      */
-    public function userMenu(Tree|null $tree): array
+    public function userMenu(?Tree $tree): array
     {
         return array_filter([
             $this->menuPendingChanges($tree),


### PR DESCRIPTION
Addresses Issue #1 

Fix PHP 7.4 compatibility by replacing union type `Tree|null` with `?Tree`

Updated the `userMenu` method in `GitHubTheme.php` to use the nullable type shorthand `?Tree` instead of `Tree|null` to ensure compatibility with PHP 7.4.